### PR TITLE
fix(docker): exec node so PID 1 receives SIGTERM directly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -40,4 +40,4 @@ EXPOSE 3001
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD wget -qO- "http://127.0.0.1:${PORT}/healthz" >/dev/null || exit 1
 
-CMD ["sh", "-c", "node \"dist/${MENAGERAI_ENTRYPOINT:-server-all}.js\""]
+CMD ["sh", "-c", "exec node \"dist/${MENAGERAI_ENTRYPOINT:-server-all}.js\""]


### PR DESCRIPTION
## What
Prepend `exec` to the container `CMD` so `node` replaces the shell as PID 1.

```diff
-CMD ["sh", "-c", "node \"dist/${MENAGERAI_ENTRYPOINT:-server-all}.js\""]
+CMD ["sh", "-c", "exec node \"dist/${MENAGERAI_ENTRYPOINT:-server-all}.js\""]
```

## Why
The `sh -c` wrapper is needed to expand `${MENAGERAI_ENTRYPOINT}`, but without `exec` the shell stays PID 1 and `node` runs as its child. On container stop, Docker sends `SIGTERM` to PID 1 (the shell), which does not forward it to `node` — so the process ignores the signal, the orchestrator waits out the grace period, and the container is finally `SIGKILL`ed. `exec` replaces the shell image with `node`, so `node` is PID 1 and receives `SIGTERM` directly for a clean, prompt shutdown.

No behavioral change beyond signal delivery; the entrypoint selection via `MENAGERAI_ENTRYPOINT` is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)