### PR TITLE
fix(bootstrap): seed the demo app only on a fresh (empty) install

### DIFF
--- a/src/bootstrap.ts
+++ b/src/bootstrap.ts
@@ -59,7 +59,14 @@ export async function ensureSuperadmin(email: string): Promise<void> {
 
 // Ensure a demo app exists (behind the gateway) and is granted to the superadmin,
 // so a fresh install has something to launch. Returns the app's proxy secret.
+//
+// Seeded ONLY on a genuinely fresh install (empty app registry). An established
+// deployment — e.g. a downstream fork that already runs real apps — gets nothing,
+// so a production portal never sprouts a stray demo tile. (This also matters
+// because seeding runs on every boot: an unconditional upsert would resurrect the
+// demo app on every restart even after an operator deleted it.)
 export async function ensureDemoApp(grantEmail: string): Promise<string | undefined> {
+  if (await col.apps.findOne({})) return undefined;
   const now = new Date();
   const existing = await col.apps.findOne({ key: 'demo' });
   const proxySecret = existing?.proxy_secret || crypto.randomBytes(32).toString('base64url');

--- a/test/bootstrap-demo-seed.test.ts
+++ b/test/bootstrap-demo-seed.test.ts
@@ -1,0 +1,40 @@
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+const { appsFindOne, appsUpdateOne, usersFindOne, usersUpdateOne } = vi.hoisted(() => ({
+  appsFindOne: vi.fn(),
+  appsUpdateOne: vi.fn(),
+  usersFindOne: vi.fn(),
+  usersUpdateOne: vi.fn(),
+}));
+
+vi.mock('../src/db', () => ({
+  col: {
+    apps: { findOne: appsFindOne, updateOne: appsUpdateOne },
+    users: { findOne: usersFindOne, updateOne: usersUpdateOne },
+  },
+}));
+
+import { ensureDemoApp } from '../src/bootstrap';
+
+afterEach(() => vi.clearAllMocks());
+
+describe('ensureDemoApp — fresh-install-only guard', () => {
+  it('does nothing when the app registry already has an app', async () => {
+    // The guard's findOne({}) returns a real app -> established deployment.
+    appsFindOne.mockResolvedValueOnce({ key: 'real-app' });
+    const res = await ensureDemoApp('admin@example.com');
+    expect(res).toBeUndefined();
+    expect(appsUpdateOne).not.toHaveBeenCalled(); // no demo upsert -> can't resurrect on restart
+  });
+
+  it('seeds the demo app on a fresh (empty) registry', async () => {
+    appsFindOne
+      .mockResolvedValueOnce(null) // guard: no apps yet
+      .mockResolvedValueOnce(null) // existing-demo lookup
+      .mockResolvedValueOnce({ key: 'demo', proxy_secret: 'sek' }); // final read for the return
+    usersFindOne.mockResolvedValue(null); // no superadmin row to grant to
+    const res = await ensureDemoApp('admin@example.com');
+    expect(appsUpdateOne).toHaveBeenCalledTimes(1); // the demo upsert ran
+    expect(res).toBe('sek');
+  });
+});


### PR DESCRIPTION
## Problem
Superadmin/demo seeding runs on **every boot** (gated on the startup preflight), and `ensureDemoApp` was an unconditional upsert. On an **established deployment** — notably a downstream fork that already runs real apps — this injects a stray **"Demo App"** tile, and because it's an idempotent upsert it **reappears on every restart even after the operator deletes it**.

## Fix
Guard `ensureDemoApp`: if the app registry already contains any app, return without seeding. A genuinely fresh install (empty registry) still gets the demo app; an established one never does.

```ts
if (await col.apps.findOne({})) return undefined;
```

## Tests
`test/bootstrap-demo-seed.test.ts` — skips when an app exists (no upsert), seeds on an empty registry. Full suite **217 passing**; tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)