### PR TITLE
Ignore operator-specific app runbooks in apps/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,13 @@ dist/
 build/
 *.tsbuildinfo
 
+# App onboarding runbooks are deployment-specific: each operator's fleet docs
+# describe their own private apps. Only the template and the worked example are
+# part of the project.
+apps/*.md
+!apps/_TEMPLATE.md
+!apps/demo.md
+
 # Environment / secrets
 .env
 .env.*


### PR DESCRIPTION
apps/ mixes two kinds of file: _TEMPLATE.md and demo.md are part of the project, while everything else an operator puts there describes their own private fleet and should never be committed.

Without a rule, each deployment has to maintain its own list in .git/info/exclude and remember to extend it whenever an app is onboarded — which is easy to forget, and the failure mode is committing internal infrastructure notes to a public repo.

Ignore apps/*.md with the two project-owned files as exceptions. Already tracked files are unaffected, so this is a no-op for existing clones.


Claude-Session: https://claude.ai/code/session_01EvFtXNQzvhDMgLiF2UNyQ2